### PR TITLE
add DomainGPT as an interesting use case for chatgpt-api

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -444,6 +444,7 @@ All of these awesome projects are built using the `chatgpt` package. 🤯
 - [Clippy the Saleforce chatbot](https://github.com/sebas00/chatgptclippy) ClippyJS joke bot
 - [ai-assistant](https://github.com/youking-lib/ai-assistant) Chat assistant
 - [Feishu Bot](https://github.com/linjungz/feishu-chatgpt-bot)
+- [DomainGPT: Discover available domain names using your product description](https://github.com/billylo1/DomainGPT)
 
 If you create a cool integration, feel free to open a PR and add it to the list.
 


### PR DESCRIPTION
help startup founders think of cool domain names for their product.